### PR TITLE
Add eui driver for stm32wle5 chips

### DIFF
--- a/boards/lora_e5_mini/src/main.rs
+++ b/boards/lora_e5_mini/src/main.rs
@@ -26,6 +26,7 @@ use kernel::utilities::single_thread_value::SingleThreadValue;
 use kernel::{create_capability, debug, static_init};
 use stm32wle5jc::chip_specs::Stm32wle5jcSpecs;
 use stm32wle5jc::clocks::msi::MSI_FREQUENCY_MHZ;
+use stm32wle5jc::device_signature::Uid64;
 use stm32wle5jc::gpio::{PinId, PortId};
 use stm32wle5jc::interrupt_service::Stm32wle5jcDefaultPeripherals;
 use stm32wle5jc::subghz_radio::SubGhzRadioVirtualGpio;
@@ -100,6 +101,7 @@ struct LoraE5Mini {
         'static,
         stm32wle5jc::rtc::Rtc<'static>,
     >,
+    eui64: &'static capsules_extra::eui64::Eui64,
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -117,6 +119,7 @@ impl SyscallDriverLookup for LoraE5Mini {
             capsules_core::i2c_master::DRIVER_NUM => f(Some(self.i2c_master)),
             kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             capsules_extra::date_time::DRIVER_NUM => f(Some(self.date_time)),
+            capsules_extra::eui64::DRIVER_NUM => f(Some(self.eui64)),
             _ => f(None),
         }
     }
@@ -466,6 +469,15 @@ pub unsafe fn main() {
     // test::rtc_dummy::run_complete_rtc_test(rtc);
 
     //--------------------------------------------------------------------
+    // EUI64 (MAC Address for LoRaWAN)
+    //--------------------------------------------------------------------
+    let uid64 = Uid64::new();
+    let device_eui64 = uid64.get_device_uid64();
+
+    let eui64 = components::eui64::Eui64Component::new(device_eui64)
+        .finalize(components::eui64_component_static!());
+
+    //--------------------------------------------------------------------
     // PROCESS CONSOLE
     //--------------------------------------------------------------------
     let process_console = components::process_console::ProcessConsoleComponent::new(
@@ -500,6 +512,7 @@ pub unsafe fn main() {
         lora_gpio,
         i2c_master,
         date_time,
+        eui64,
     };
 
     assert!(base_peripherals.subghz_spi.is_enabled_clock());

--- a/chips/stm32wle5jc/src/lib.rs
+++ b/chips/stm32wle5jc/src/lib.rs
@@ -5,7 +5,8 @@
 #![no_std]
 
 pub use stm32wle5xx::{
-    chip, clocks, exti, gpio, i2c, nvic, pwr, rcc, rtc, spi, subghz_radio, syscfg, tim2, usart,
+    chip, clocks, device_signature, exti, gpio, i2c, nvic, pwr, rcc, rtc, spi, subghz_radio,
+    syscfg, tim2, usart,
 };
 
 pub mod chip_specs;

--- a/chips/stm32wle5xx/src/device_signature.rs
+++ b/chips/stm32wle5xx/src/device_signature.rs
@@ -3,25 +3,28 @@
 // Copyright Tock Contributors 2025.
 
 use kernel::utilities::registers::interfaces::Readable;
-use kernel::utilities::registers::{register_bitfields, ReadOnly};
+use kernel::utilities::registers::{register_bitfields, register_structs, ReadOnly};
 use kernel::utilities::StaticRef;
 
-struct Uid64Registers {
-    uid_high: ReadOnly<u32, UIDHIGH::Register>,
-    uid_low: ReadOnly<u32, UIDLOW::Register>,
+register_structs! {
+    Uid64Registers {
+        (0x0 => uid64_low: ReadOnly<u32, UID64LOW::Register>),
+        (0x4 => uid64_high: ReadOnly<u32, UID64HIGH::Register>),
+        (0x8 => @END),
+    }
 }
 
 register_bitfields![u32,
-    UIDHIGH [
+    UID64LOW [
         /// Device number.
-        UID OFFSET(0) NUMBITS(32) []
+        UID OFFSET(0) NUMBITS(32) [],
     ],
-    UIDLOW [
+    UID64HIGH [
         /// Company ID - 0x0080E1 for STMicroelectronics.
         STID OFFSET(8) NUMBITS(24) [],
         /// Device ID.
         DEVID OFFSET(0) NUMBITS(8) []
-    ]
+    ],
 ];
 
 const UID64_BASE: StaticRef<Uid64Registers> =
@@ -39,8 +42,13 @@ impl Uid64 {
     }
 
     pub fn get_device_uid64(&self) -> u64 {
-        let uid_high = self.registers.uid_high.get();
-        let uid_low = self.registers.uid_low.get();
-        ((uid_high as u64) << 32) | (uid_low as u64)
+        let uid_high = self.registers.uid64_high.get();
+        let uid_low = self.registers.uid64_low.get();
+
+        // expected output: 2e8d470515e18000
+        let uid = ((uid_high as u64) << 32) | (uid_low as u64);
+
+        // need to swap byte order: 0080e11505478d2e
+        uid.swap_bytes()
     }
 }

--- a/chips/stm32wle5xx/src/device_signature.rs
+++ b/chips/stm32wle5xx/src/device_signature.rs
@@ -45,10 +45,8 @@ impl Uid64 {
         let uid_high = self.registers.uid64_high.get();
         let uid_low = self.registers.uid64_low.get();
 
-        // expected output: 2e8d470515e18000
         let uid = ((uid_high as u64) << 32) | (uid_low as u64);
 
-        // need to swap byte order: 0080e11505478d2e
         uid.swap_bytes()
     }
 }


### PR DESCRIPTION
### Pull Request Overview

Add support for device eui so that userspace LoRaWAN can be configured with the assigned device EUI. Grabs the EUI from the UID64 in flash on the device.


See "Device Electronic Signature" chapter in reference manual.



### Testing Strategy


Tested with `libtock-c/examples/tests/eui/` and got the following output.
```
EUI-64: 0080e11505478d2e
```
The upper 4 bytes are static and checked against expected values. *Have note tested connecting the device to a LoRaWAN network*.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.

Used github copilot.
