### PR TITLE
More I2C fixes

### DIFF
--- a/boards/lora_e5_mini/src/main.rs
+++ b/boards/lora_e5_mini/src/main.rs
@@ -422,7 +422,9 @@ pub unsafe fn main() {
     });
 
     base_peripherals.i2c2.enable_clock();
-    base_peripherals.i2c2.set_speed(stm32wle5jc::i2c::I2CSpeed::Speed400k);
+    base_peripherals
+        .i2c2
+        .set_speed(stm32wle5jc::i2c::I2CSpeed::Speed400k);
     let i2c_master = components::i2c::I2CMasterDriverComponent::new(
         board_kernel,
         capsules_core::i2c_master::DRIVER_NUM,

--- a/boards/lora_e5_mini/src/main.rs
+++ b/boards/lora_e5_mini/src/main.rs
@@ -421,6 +421,7 @@ pub unsafe fn main() {
     });
 
     base_peripherals.i2c2.enable_clock();
+    base_peripherals.i2c2.set_speed(stm32wle5jc::i2c::I2CSpeed::Speed100k);
     let i2c_master = components::i2c::I2CMasterDriverComponent::new(
         board_kernel,
         capsules_core::i2c_master::DRIVER_NUM,

--- a/boards/lora_e5_mini/src/main.rs
+++ b/boards/lora_e5_mini/src/main.rs
@@ -422,7 +422,7 @@ pub unsafe fn main() {
     });
 
     base_peripherals.i2c2.enable_clock();
-    base_peripherals.i2c2.set_speed(stm32wle5jc::i2c::I2CSpeed::Speed100k);
+    base_peripherals.i2c2.set_speed(stm32wle5jc::i2c::I2CSpeed::Speed400k);
     let i2c_master = components::i2c::I2CMasterDriverComponent::new(
         board_kernel,
         capsules_core::i2c_master::DRIVER_NUM,

--- a/boards/lora_e5_mini/src/main.rs
+++ b/boards/lora_e5_mini/src/main.rs
@@ -415,6 +415,7 @@ pub unsafe fn main() {
 
     // SCL
     gpio_ports.get_pin(PinId::PB15).map(|pin| {
+        pin.set_mode_output_opendrain();
         pin.set_mode(stm32wle5jc::gpio::Mode::AlternateFunctionMode);
         pin.set_floating_state(kernel::hil::gpio::FloatingState::PullNone);
         pin.set_alternate_function(stm32wle5jc::gpio::AlternateFunction::AF4);

--- a/chips/stm32wle5xx/src/i2c.rs
+++ b/chips/stm32wle5xx/src/i2c.rs
@@ -326,10 +326,13 @@ impl<'a> I2C<'a> {
 
         match speed {
             I2CSpeed::Speed100k => {
-                self.registers.timingr.set(0x00303D5B);
+                self.registers.timingr.set(0xE14);
+
+                //self.registers.timingr.set(0x00303D5B);
             }
             I2CSpeed::Speed400k => {
-                self.registers.timingr.set(0x0010061A);
+                self.registers.timingr.set(0x4);
+                //self.registers.timingr.set(0x0010061A);
             }
         }
 


### PR DESCRIPTION
### Pull Request Overview

- Configures open drain on SCL line. Fixes communication with devices that implement clk stretching
- Actually set timing from the kernel
- Fix i2c timing registers.
- Update clk to 400k 


### Testing Strategy

Me, verified with logic

<img width="1376" height="529" alt="image" src="https://github.com/user-attachments/assets/6fabb32c-5289-4d8b-9cbc-b8c84c753192" />


### TODO or Help Wanted

N/A

### Tock + ENTS Developer PR Form

- [x] Completed Developer Effort [PR Form](https://docs.google.com/forms/d/1tBf1-ZN9E3iTkloLVHI2tce5ONr77UlecSj8_i53F7Q/viewform?edit_requested=true)

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.

### AI Use

- [ ] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
