### PR TITLE
Reduce stack size

### DIFF
--- a/boards/lora_e5_mini/src/main.rs
+++ b/boards/lora_e5_mini/src/main.rs
@@ -64,7 +64,7 @@ const LORA_GPIO_DRIVER_NUM: usize = capsules_core::driver::NUM::LoRaPhyGPIO as u
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]
-pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
+pub static mut STACK_MEMORY: [u8; 0x1500] = [0; 0x1500];
 
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.


### PR DESCRIPTION
### Pull Request Overview

This pull request adds/changes/fixes...

Reduces stack size for kernel to `0x1500`. To get more stack for apps.
With `0x1000` could not get debug messages if something crashed.

### Testing Strategy

This pull request was tested by...

Trial and error to find right value.

### TODO or Help Wanted

This pull request still needs...

### Tock + ENTS Developer PR Form

- [ ] Completed Developer Effort [PR Form](https://docs.google.com/forms/d/1tBf1-ZN9E3iTkloLVHI2tce5ONr77UlecSj8_i53F7Q/viewform?edit_requested=true)

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.

### AI Use

- [ ] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
