### PR TITLE
Add sdi12 kernel support

### DIFF
--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -85,6 +85,7 @@ pub mod sched;
 pub mod screen;
 pub mod screen_adapters;
 pub mod screen_on;
+pub mod sdi12;
 pub mod segger_rtt;
 pub mod servo;
 pub mod sh1106;

--- a/boards/components/src/sdi12.rs
+++ b/boards/components/src/sdi12.rs
@@ -1,0 +1,146 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! Components for SDI-12 environmental sensor interface.
+//!
+//! SDI-12 uses UART as the bus protocol in conjunction with a command pin GPIO.
+//! This component provides a simplified interface to set up an SDI-12 peripheral
+//! using a multiplexed UART connection.
+//!
+//! Usage
+//! -----
+//! ```rust
+//! let uart_mux = UartMuxComponent::new(&sam4l::usart::USART3,
+//!                                      1200,
+//!                                      deferred_caller).finalize(components::uart_mux_component_static!());
+//! let sdi12 = Sdi12Component::new(uart_mux)
+//!    .finalize(sdi12_component_static!());
+//! ```
+
+use capsules_core::virtualizers::virtual_uart::{MuxUart, UartDevice};
+use capsules_extra::sdi12_ents::Sdi12Ents;
+use core::mem::MaybeUninit;
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil;
+
+#[macro_export]
+macro_rules! sdi12_component_static {
+    // Common logic for buffer allocation
+    ($rx_buffer_len: expr, $tx_buffer_len: expr) => {{
+        use capsules_core::virtualizers::virtual_uart::UartDevice;
+        use kernel::static_buf;
+        let read_buf = static_buf!([u8; $rx_buffer_len]);
+        let write_buf = static_buf!([u8; $tx_buffer_len]);
+        // Create virtual device for SDI-12.
+        let sdi12_uart = static_buf!(UartDevice);
+        (write_buf, read_buf, sdi12_uart)
+    }};
+    () => {
+        $crate::sdi12_component_static!(64, 64);
+    };
+    ($rx_buffer_len: literal, $tx_buffer_len: literal) => {
+        $crate::sdi12_component_static!($rx_buffer_len, $tx_buffer_len);
+    };
+}
+
+#[macro_export]
+macro_rules! sdi12_ents_static {
+    ($S:ty $(,)?) => {{
+        use capsules_extra::sdi12_ents::Sdi12Ents;
+        let _tx_buf = kernel::static_init!([u8; 64], [0; 64]);
+        let _rx_buf = kernel::static_init!([u8; 64], [0; 64]);
+        let sdi12_ents = kernel::static_init!(
+            core::mem::MaybeUninit<Sdi12Ents<'static, $S>>,
+            core::mem::MaybeUninit::uninit()
+        );
+        (sdi12_ents, _tx_buf, _rx_buf)
+    }};
+}
+
+/// Helper function to initialize SDI-12 userspace driver.
+///
+/// This function handles the full SDI-12 driver setup including buffer allocation,
+/// grant allocation, and userspace driver interface setup.
+///
+/// Note: The caller must ensure the returned pointer is stored in static memory
+/// and lives for the entire program lifetime.
+pub fn init_sdi12_ents<'a, S>(
+    board_kernel: &'static kernel::Kernel,
+    driver_num: usize,
+    sdi12_driver: &'a S,
+    (sdi12_ents, tx_buffer, rx_buffer): (
+        &'static mut MaybeUninit<Sdi12Ents<'a, S>>,
+        &'static mut [u8; 64],
+        &'static mut [u8; 64],
+    ),
+) -> &'static Sdi12Ents<'a, S>
+where
+    S: hil::sdi12::Transmit<'a> + hil::sdi12::Receive<'a>,
+{
+    let sdi12_grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+    let sdi12_driver_process_grant = board_kernel.create_grant(driver_num, &sdi12_grant_cap);
+
+    let sdi12_ents_ref = sdi12_ents.write(Sdi12Ents::new(
+        tx_buffer,
+        rx_buffer,
+        sdi12_driver,
+        sdi12_driver_process_grant,
+    ));
+
+    sdi12_driver.set_transmit_client(sdi12_ents_ref);
+    sdi12_driver.set_receive_client(sdi12_ents_ref);
+
+    sdi12_ents_ref
+}
+
+/// Component for SDI-12 environmental sensor driver.
+///
+/// This component initializes an SDI-12 driver using a virtual UART device
+/// from a UART mux. It provides both transmit and receive capabilities
+/// for communicating with SDI-12 sensors.
+pub struct Sdi12Component<const RX_BUF_LEN: usize, const TX_BUF_LEN: usize> {
+    uart_mux: &'static MuxUart<'static>,
+    #[allow(dead_code)]
+    driver_num: usize,
+}
+
+impl<const RX_BUF_LEN: usize, const TX_BUF_LEN: usize> Sdi12Component<RX_BUF_LEN, TX_BUF_LEN> {
+    pub fn new(
+        uart_mux: &'static MuxUart<'static>,
+        driver_num: usize,
+    ) -> Sdi12Component<RX_BUF_LEN, TX_BUF_LEN> {
+        Sdi12Component {
+            uart_mux,
+            driver_num,
+        }
+    }
+}
+
+impl<const RX_BUF_LEN: usize, const TX_BUF_LEN: usize> Component
+    for Sdi12Component<RX_BUF_LEN, TX_BUF_LEN>
+{
+    type StaticInput = (
+        &'static mut MaybeUninit<[u8; TX_BUF_LEN]>,
+        &'static mut MaybeUninit<[u8; RX_BUF_LEN]>,
+        &'static mut MaybeUninit<UartDevice<'static>>,
+    );
+    type Output = &'static UartDevice<'static>;
+
+    fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let _write_buffer = s.0.write([0; TX_BUF_LEN]);
+
+        let _read_buffer = s.1.write([0; RX_BUF_LEN]);
+
+        let sdi12_uart = s.2.write(UartDevice::new(self.uart_mux, true));
+        sdi12_uart.setup();
+
+        // Set up transmit and receive clients (applications will hook into this)
+        // hil::uart::Transmit::set_transmit_client(sdi12_uart, client);
+        // hil::uart::Receive::set_receive_client(sdi12_uart, client);
+
+        sdi12_uart
+    }
+}

--- a/boards/lora_e5_mini/src/main.rs.orig
+++ b/boards/lora_e5_mini/src/main.rs.orig
@@ -15,16 +15,13 @@
 use core::ptr::addr_of_mut;
 
 use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
-use capsules_extra::sdi12_ents::Sdi12Ents;
 use components::gpio::GpioComponent;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::debug::PanicResources;
-use kernel::hil::gpio::{Configure as GpioConfigure, Output};
+use kernel::hil::gpio::{Configure, Output};
 use kernel::hil::led::LedLow;
-use kernel::hil::time::Alarm;
 use kernel::hil::time::Counter;
-use kernel::hil::uart::{self, Configure as UartConfigure, Receive, Transmit};
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::utilities::single_thread_value::SingleThreadValue;
 use kernel::{create_capability, debug, static_init};
@@ -34,6 +31,7 @@ use stm32wle5jc::device_signature::Uid64;
 use stm32wle5jc::gpio::{PinId, PortId};
 use stm32wle5jc::interrupt_service::Stm32wle5jcDefaultPeripherals;
 use stm32wle5jc::subghz_radio::SubGhzRadioVirtualGpio;
+use components::gpio::GpioComponent;
 
 /// Support routines for debugging I/O.
 pub mod io;
@@ -106,15 +104,11 @@ struct LoraE5Mini {
         stm32wle5jc::rtc::Rtc<'static>,
     >,
     eui64: &'static capsules_extra::eui64::Eui64,
+<<<<<<< HEAD
     gpio: &'static capsules_core::gpio::GPIO<'static, stm32wle5jc::gpio::Pin<'static>>,
-    sdi12_ents: &'static Sdi12Ents<
-        'static,
-        stm32wle5jc::sdi12::Sdi12<
-            'static,
-            stm32wle5jc::usart::Usart<'static>,
-            VirtualMuxAlarm<'static, stm32wle5jc::tim2::Tim2<'static>>,
-        >,
-    >,
+=======
+    gpio: &'static capsules_core::gpio::GPIO<'static, stm32wle5jc::gpio::Pin<'static>>
+>>>>>>> 0f2ed3ca9 (Added gpio syscall interface)
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -134,7 +128,6 @@ impl SyscallDriverLookup for LoraE5Mini {
             capsules_extra::date_time::DRIVER_NUM => f(Some(self.date_time)),
             capsules_extra::eui64::DRIVER_NUM => f(Some(self.eui64)),
             capsules_core::gpio::DRIVER_NUM => f(Some(self.gpio)),
-            capsules_extra::sdi12_ents::DRIVER_NUM => f(Some(self.sdi12_ents)),
             _ => f(None),
         }
     }
@@ -288,7 +281,6 @@ pub unsafe fn main() {
     let gpio_ports = &base_peripherals.gpio_ports;
     gpio_ports.get_port_from_port_id(PortId::B).enable_clock();
     gpio_ports.get_port_from_port_id(PortId::A).enable_clock();
-    gpio_ports.get_port_from_port_id(PortId::C).enable_clock();
 
     //--------------------------------------------------------------------
     // Usart
@@ -493,6 +485,42 @@ pub unsafe fn main() {
     let eui64 = components::eui64::Eui64Component::new(device_eui64)
         .finalize(components::eui64_component_static!());
 
+
+    //--------------------------------------------------------------------
+    // GPIO
+    //--------------------------------------------------------------------
+  
+
+    // ordering was done by going counterclockwise around available pins on the Wio-E5 from
+    // KiCAD
+
+
+    let gpio = GpioComponent::new(
+        board_kernel,
+        capsules_core::gpio::DRIVER_NUM,
+        components::gpio_component_helper!(
+            stm32wle5jc::gpio::Pin,
+            // wakeup pin 
+            1 => gpio_ports.get_pin(PinId::PA00).unwrap(),
+            // ADC_DRDY
+            2 => gpio_ports.get_pin(PinId::PC00).unwrap(),
+            // PG
+            3 => gpio_ports.get_pin(PinId::PA10).unwrap(),
+            // CHG
+            4 => gpio_ports.get_pin(PinId::PB14).unwrap(),
+            // VBAT/2
+            5 => gpio_ports.get_pin(PinId::PB13).unwrap(),
+            // ESP32_EN
+            6 => gpio_ports.get_pin(PinId::PB10).unwrap(),
+            // POWERDOWN
+            7 => gpio_ports.get_pin(PinId::PA09).unwrap()
+
+        )
+    )
+    .finalize(components::gpio_component_static!(stm32wle5jc::gpio::Pin));
+            
+
+
     //--------------------------------------------------------------------
     // GPIO
     //--------------------------------------------------------------------
@@ -523,84 +551,6 @@ pub unsafe fn main() {
         ),
     )
     .finalize(components::gpio_component_static!(stm32wle5jc::gpio::Pin));
-
-    //--------------------------------------------------------------------
-    // SDI12
-    //--------------------------------------------------------------------
-
-    // Setup USART2 GPIO pins: PA2=TX, PA3=RX
-    gpio_ports.get_pin(PinId::PA02).map(|pin| {
-        pin.make_output();
-        pin.set_floating_state(kernel::hil::gpio::FloatingState::PullNone);
-        pin.set_mode(stm32wle5jc::gpio::Mode::AlternateFunctionMode);
-        pin.set_alternate_function(stm32wle5jc::gpio::AlternateFunction::AF7);
-    });
-
-    gpio_ports.get_pin(PinId::PA03).map(|pin| {
-        pin.make_input();
-        pin.set_mode(stm32wle5jc::gpio::Mode::AlternateFunctionMode);
-        pin.set_alternate_function(stm32wle5jc::gpio::AlternateFunction::AF7);
-    });
-
-    // setup usart2 peripheral
-    // NOTE: This configuration is contrary to 7E1 specified by SDI12. The STM32 peripheral
-    // includes the parity bit as part of the width. So by a width of 8E1, the 8th bit is the
-    // parity bit. Also needs to be cleared in software, go figure...
-    base_peripherals.usart2.enable_clock();
-    let _ = base_peripherals.usart2.configure(uart::Parameters {
-        baud_rate: 1200,
-        width: uart::Width::Eight,
-        stop_bits: uart::StopBits::One,
-        parity: uart::Parity::Even,
-        hw_flow_control: false,
-    });
-
-    // Pin to control direction (default low)
-    let sdi12_command_pin = gpio_ports.get_pin(PinId::PC01).unwrap();
-    sdi12_command_pin.make_output();
-    sdi12_command_pin.set_floating_state(kernel::hil::gpio::FloatingState::PullNone);
-    sdi12_command_pin.clear();
-
-    // Alarm for SDI-12 timing
-    let virtual_alarm = static_init!(
-        VirtualMuxAlarm<'static, stm32wle5jc::tim2::Tim2<'static>>,
-        VirtualMuxAlarm::new(mux_alarm)
-    );
-    virtual_alarm.setup();
-
-    // Pin for breaking signal (need to pass directly to SDI-12 driver)
-    let sdi12_usart_pin = gpio_ports.get_pin(PinId::PA02).unwrap();
-
-    let sdi12_driver = static_init!(
-        stm32wle5jc::sdi12::Sdi12<
-            'static,
-            stm32wle5jc::usart::Usart<'static>,
-            VirtualMuxAlarm<'static, stm32wle5jc::tim2::Tim2<'static>>,
-        >,
-        stm32wle5jc::sdi12::Sdi12::new(
-            &base_peripherals.usart2,
-            sdi12_usart_pin,
-            sdi12_command_pin,
-            virtual_alarm,
-        )
-    );
-
-    virtual_alarm.set_alarm_client(sdi12_driver);
-    base_peripherals.usart2.set_transmit_client(sdi12_driver);
-    base_peripherals.usart2.set_receive_client(sdi12_driver);
-
-    let sdi12_ents = components::sdi12::init_sdi12_ents(
-        board_kernel,
-        capsules_extra::sdi12_ents::DRIVER_NUM,
-        sdi12_driver,
-        components::sdi12_ents_static!(
-            stm32wle5jc::sdi12::Sdi12<
-                'static,
-                stm32wle5jc::usart::Usart<'static>,
-                VirtualMuxAlarm<'static, stm32wle5jc::tim2::Tim2<'static>>,
-            >,
-        ),
-    );
 
     //--------------------------------------------------------------------
     // PROCESS CONSOLE
@@ -638,8 +588,11 @@ pub unsafe fn main() {
         i2c_master,
         date_time,
         eui64,
+<<<<<<< HEAD
         gpio,
-        sdi12_ents,
+=======
+        gpio
+>>>>>>> 0f2ed3ca9 (Added gpio syscall interface)
     };
 
     assert!(base_peripherals.subghz_spi.is_enabled_clock());

--- a/capsules/core/src/driver.rs
+++ b/capsules/core/src/driver.rs
@@ -36,6 +36,7 @@ pub enum NUM {
     UsbUser               = 0x20005,
     I2cMasterSlave        = 0x20006,
     Can                   = 0x20007,
+    Sdi12Ents             = 0x20008,
 
     // Networking
     BleAdvertising        = 0x30000,

--- a/capsules/extra/README.md
+++ b/capsules/extra/README.md
@@ -113,6 +113,7 @@ These capsules provide a `Driver` interface for common MCU peripherals.
 - **[CRC](src/crc.rs)**: CRC calculation.
 - **[DAC](src/dac.rs)**: Digital to analog conversion.
 - **[CAN](src/can.rs)**: CAN communication.
+- **[SDI12 ENTS](src/sdi12_ents.rs)**: SDI12 Communication across the ENTS board
 
 
 Helpful Userspace Capsules

--- a/capsules/extra/src/lib.rs
+++ b/capsules/extra/src/lib.rs
@@ -91,6 +91,7 @@ pub mod rf233;
 pub mod rf233_const;
 pub mod screen;
 pub mod sdcard;
+pub mod sdi12_ents;
 pub mod servo;
 pub mod seven_segment;
 pub mod sg90;

--- a/capsules/extra/src/sdi12_ents.rs
+++ b/capsules/extra/src/sdi12_ents.rs
@@ -1,0 +1,325 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+// Written by Stephen Taylor, UCSD, 2025
+
+//! Provides userspace with access to sdi12 environmental sensors. sdi12 uses UART as a bus protocol in conjunction with a command pin gpio.
+//!
+//! Userspace Interface
+//! -------------------
+//!
+//! ### `command` System Call
+//!
+//! The `command` system call support one argument `cmd` which is used to specify the
+//! operation, currently the following cmd's are supported:
+//!
+//! * `0`: check whether the driver exists
+//! * `1`: query the address of connected SDI12 sensor. Note this requires the command pin to be connected.
+//! If multiple sensors are connected, they will all respond to this command and may result in bus contention.
+//!
+//!
+
+use enum_primitive::enum_from_primitive;
+
+use capsules_core::driver;
+use core::cell::Cell;
+use kernel::errorcode::ErrorCode;
+use kernel::grant::UpcallCount;
+use kernel::grant::{AllowRoCount, AllowRwCount, Grant};
+use kernel::hil::sdi12;
+use kernel::hil::sdi12::TransmitClient;
+use kernel::processbuffer::ReadableProcessBuffer;
+use kernel::processbuffer::WriteableProcessBuffer;
+use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::cells::TakeCell;
+use kernel::ProcessId;
+
+pub const DRIVER_NUM: usize = driver::NUM::Sdi12Ents as usize;
+
+pub enum Sdi12Status {
+    Sdi12Ok = 0,
+    Sdi12Error = -1,
+    Sdi12TimeoutOnRead = -2,
+    Sdi12ParsingError = -3,
+}
+
+#[derive(Copy, Clone, PartialEq)]
+pub struct Sdi12MeasurmentValues {
+    address: u8,
+    time: u16,
+    numvalues: u8,
+}
+pub enum State {
+    Idle,
+    AddressRequest,
+    GivingAddress,
+    WakingSensors,
+    SendingCommand,
+    ReadingResponse,
+}
+
+/// IDs for subscribed upcalls.
+mod upcall {
+    /// Sdi12 received.
+    pub const SDI12_RX: usize = 0;
+    /// Sdi12 transmit complete.
+    pub const SDI12_TX: usize = 1;
+    /// Number of upcalls.
+    pub const COUNT: u8 = 2;
+}
+
+mod ro_allow {
+    /// Tx buffer for SDI12 transmit.
+    pub const TX_BUFFER: usize = 0;
+    /// Number of read-only allow buffers.
+    pub const COUNT: u8 = 1;
+}
+
+mod rw_allow {
+    /// Rx buffer for SDI12 receive.
+    pub const RX_BUFFER: usize = 0;
+    /// Number of read-write allow buffers.
+    pub const COUNT: u8 = 1;
+}
+
+pub struct Sdi12Ents<'a, S: sdi12::Transmit<'a> + sdi12::Receive<'a>> {
+    state: Cell<State>,
+    tx_buffer: TakeCell<'static, [u8]>,
+    rx_buffer: TakeCell<'static, [u8]>,
+    sdi12: &'a S,
+    grant: Grant<
+        App,
+        UpcallCount<{ upcall::COUNT }>,
+        AllowRoCount<{ ro_allow::COUNT }>,
+        AllowRwCount<{ rw_allow::COUNT }>,
+    >,
+    tx_in_progress: OptionalCell<ProcessId>,
+    rx_in_progress: OptionalCell<ProcessId>,
+}
+
+/// Holds buffers and whatnot that the application has passed us.
+#[derive(Default)]
+pub struct App;
+
+impl<'a, S: sdi12::Transmit<'a> + sdi12::Receive<'a>> Sdi12Ents<'a, S> {
+    pub fn new(
+        tx_buffer: &'static mut [u8],
+        rx_buffer: &'static mut [u8],
+        sdi12: &'a S,
+        grant: Grant<
+            App,
+            UpcallCount<{ upcall::COUNT }>,
+            AllowRoCount<{ ro_allow::COUNT }>,
+            AllowRwCount<{ rw_allow::COUNT }>,
+        >,
+    ) -> Sdi12Ents<'a, S> {
+        Sdi12Ents {
+            state: Cell::new(State::Idle),
+            tx_buffer: TakeCell::new(tx_buffer),
+            rx_buffer: TakeCell::new(rx_buffer),
+            sdi12,
+            grant,
+            tx_in_progress: OptionalCell::empty(),
+            rx_in_progress: OptionalCell::empty(),
+        }
+    }
+
+    /**
+     ******************************************************************************
+     * @brief    Send data previously copied into tx_buffer
+     *
+     * @param    self,
+     * @param    len, usize
+     * @return   Result<(), ErrorCode>
+     ******************************************************************************
+     */
+    pub fn sdi12_send_from_buffer(&self, len: usize) -> Result<(), ErrorCode> {
+        self.state.set(State::SendingCommand);
+
+        if let Some(buffer) = self.tx_buffer.take() {
+            match self.sdi12.transmit(buffer, len) {
+                Ok(()) => Ok(()),
+                Err((e, buf)) => {
+                    self.tx_buffer.replace(buf);
+                    Err(e)
+                }
+            }
+        } else {
+            Err(ErrorCode::NOMEM)
+        }
+    }
+
+    /**
+     ******************************************************************************
+     * @brief    Start a receive via SDI12
+     *
+     * @param    self,
+     * @param    processid, ProcessID
+     * @param    size, usize
+     * @return   Sdi12Status
+     ******************************************************************************
+     */
+    pub fn sdi12_start_receive(&self, size: usize) -> Result<Sdi12Status, Sdi12Status> {
+        // take a kernel rx buffer
+        if let Some(buf) = self.rx_buffer.take() {
+            match self.sdi12.receive(buf, size) {
+                Ok(()) => {
+                    self.state.set(State::ReadingResponse);
+                    Ok(Sdi12Status::Sdi12Ok)
+                }
+                Err((_ecode, returned_buf)) => {
+                    // restore kernel buffer and return a generic SDI12 error
+                    self.rx_buffer.replace(returned_buf);
+                    Err(Sdi12Status::Sdi12Error)
+                }
+            }
+        } else {
+            Err(Sdi12Status::Sdi12Error)
+        }
+    }
+}
+
+use enum_primitive::cast::FromPrimitive;
+
+enum_from_primitive! {
+    #[derive(Debug, PartialEq, Clone, Copy)]
+    pub enum Cmd {
+        Ping = 0,
+        Write = 1,
+        Read = 2,
+        WhoKnows = 3,
+    }
+}
+
+impl<'a, S> SyscallDriver for Sdi12Ents<'a, S>
+where
+    S: sdi12::Transmit<'a> + sdi12::Receive<'a>,
+{
+    fn command(
+        &self,
+        command_num: usize,
+        _data1: usize,
+        data2: usize,
+        processid: ProcessId,
+    ) -> CommandReturn {
+        if let Some(cmd) = Cmd::from_usize(command_num) {
+            match cmd {
+                // Driver existence check
+                Cmd::Ping => CommandReturn::success(),
+                // test send data command
+                Cmd::Write => {
+                    self.tx_in_progress.set(processid);
+                    // copy data from userspace buffer to kernel
+                    let len = self.grant.enter(processid, |_app, kernel_data| {
+                        let mut copied_len = 0;
+                        if let Ok(buffer) =
+                            kernel_data.get_readonly_processbuffer(ro_allow::TX_BUFFER)
+                        {
+                            let _ = buffer.enter(|data| {
+                                let max_len = data.len().min(self.tx_buffer.map_or(0, |b| b.len()));
+                                self.tx_buffer.map(|tx_buf| {
+                                    data[..max_len].copy_to_slice(&mut tx_buf[..max_len]);
+                                    copied_len = max_len;
+                                });
+                            });
+                        }
+                        copied_len
+                    });
+
+                    match len {
+                        Ok(l) if l > 0 => match self.sdi12_send_from_buffer(l) {
+                            Ok(()) => CommandReturn::success(),
+                            Err(_) => {
+                                self.tx_in_progress.clear();
+                                CommandReturn::failure(ErrorCode::FAIL)
+                            }
+                        },
+                        _ => {
+                            self.tx_in_progress.clear();
+                            CommandReturn::failure(ErrorCode::INVAL)
+                        }
+                    }
+                }
+                Cmd::Read => {
+                    self.rx_in_progress.set(processid);
+                    // test read data command
+                    let size = data2;
+
+                    // start receive and record process
+                    match self.sdi12_start_receive(size) {
+                        Ok(_) => CommandReturn::success(),
+                        Err(_) => CommandReturn::failure(ErrorCode::FAIL),
+                    }
+                }
+                Cmd::WhoKnows => CommandReturn::success(),
+            }
+        } else {
+            CommandReturn::failure(ErrorCode::NOSUPPORT)
+        }
+    }
+
+    fn allocate_grant(&self, processid: ProcessId) -> Result<(), kernel::process::Error> {
+        // Allocation is performed implicitly when the grant region is entered.
+        self.grant.enter(processid, |_, _| {})
+    }
+}
+
+impl<'a, S: sdi12::Transmit<'a> + sdi12::Receive<'a>> TransmitClient for Sdi12Ents<'a, S> {
+    fn transmitted_buffer(
+        &self,
+        buffer: &'static mut [u8],
+        length: usize,
+        status: Result<(), ErrorCode>,
+    ) {
+        // Put the buffer back into the TakeCell for reuse
+        self.tx_buffer.replace(buffer);
+        self.state.set(State::Idle);
+
+        // Schedule upcall to notify userspace
+        self.tx_in_progress.take().map(|processid| {
+            let _ = self.grant.enter(processid, |_app, kernel_data| {
+                let _ = kernel_data.schedule_upcall(
+                    upcall::SDI12_TX,
+                    (kernel::errorcode::into_statuscode(status), length, 0),
+                );
+            });
+        });
+    }
+}
+
+impl<'a, S: sdi12::Transmit<'a> + sdi12::Receive<'a>> sdi12::ReceiveClient for Sdi12Ents<'a, S> {
+    fn receive_buffer(
+        &self,
+        buffer: &'static mut [u8],
+        length: usize,
+        status: Result<(), ErrorCode>,
+        _error: kernel::hil::uart::Error,
+    ) {
+        // Copy received data to userspace buffer
+        self.rx_in_progress.map(|processid| {
+            let _ = self.grant.enter(processid, |_app, kernel_data| {
+                if let Ok(user_buf) = kernel_data.get_readwrite_processbuffer(rw_allow::RX_BUFFER) {
+                    let _ = user_buf.mut_enter(|dest| {
+                        let copy_len = length.min(dest.len());
+                        dest[..copy_len].copy_from_slice(&buffer[..copy_len]);
+                    });
+                }
+            });
+        });
+
+        // Put the buffer back into the TakeCell for reuse
+        self.rx_buffer.replace(buffer);
+
+        // Schedule upcall to notify userspace
+        self.rx_in_progress.take().map(|processid| {
+            let _ = self.grant.enter(processid, |_app, kernel_data| {
+                let _ = kernel_data.schedule_upcall(
+                    upcall::SDI12_RX,
+                    (kernel::errorcode::into_statuscode(status), length, 0),
+                );
+            });
+        });
+    }
+}

--- a/chips/stm32wle5jc/src/lib.rs
+++ b/chips/stm32wle5jc/src/lib.rs
@@ -5,7 +5,7 @@
 #![no_std]
 
 pub use stm32wle5xx::{
-    chip, clocks, device_signature, exti, gpio, i2c, nvic, pwr, rcc, rtc, spi, subghz_radio,
+    chip, clocks, device_signature, exti, gpio, i2c, nvic, pwr, rcc, rtc, sdi12, spi, subghz_radio,
     syscfg, tim2, usart,
 };
 

--- a/chips/stm32wle5xx/src/gpio.rs
+++ b/chips/stm32wle5xx/src/gpio.rs
@@ -389,10 +389,10 @@ register_bitfields![u32,
 ];
 
 const GPIOH_BASE: StaticRef<GpioRegisters> =
-    unsafe { StaticRef::new(0x40001C00 as *const GpioRegisters) };
+    unsafe { StaticRef::new(0x48001C00 as *const GpioRegisters) };
 
 const GPIOC_BASE: StaticRef<GpioRegisters> =
-    unsafe { StaticRef::new(0x40000800 as *const GpioRegisters) };
+    unsafe { StaticRef::new(0x48000800 as *const GpioRegisters) };
 
 const GPIOB_BASE: StaticRef<GpioRegisters> =
     unsafe { StaticRef::new(0x48000400 as *const GpioRegisters) };

--- a/chips/stm32wle5xx/src/lib.rs
+++ b/chips/stm32wle5xx/src/lib.rs
@@ -22,6 +22,7 @@ pub mod i2c;
 pub mod pwr;
 pub mod rcc;
 pub mod rtc;
+pub mod sdi12;
 pub mod spi;
 pub mod subghz_radio;
 pub mod syscfg;

--- a/chips/stm32wle5xx/src/sdi12.rs
+++ b/chips/stm32wle5xx/src/sdi12.rs
@@ -1,0 +1,181 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+use kernel::hil::gpio::{Configure, Output};
+use kernel::hil::sdi12;
+use kernel::hil::time::{Alarm, AlarmClient, ConvertTicks};
+use kernel::hil::uart::{self, Uart};
+
+use kernel::hil::uart::Error;
+use kernel::utilities::cells::{MapCell, OptionalCell};
+
+use kernel::ErrorCode;
+
+const WAKE_SENSORS_INTERVAL_MS: u32 = 13;
+const MARKING_INTERVAL_MS: u32 = 9;
+
+use crate::gpio::{AlternateFunction, Mode};
+
+enum Sdi12State {
+    TxBreak(usize, &'static mut [u8]),
+    Tx(usize, &'static mut [u8]),
+    Idle,
+}
+
+pub struct Sdi12<'a, U: Uart<'a>, A: Alarm<'a>> {
+    uart: &'a U,
+    uart_pin: &'a crate::gpio::Pin<'a>,
+    command_pin: &'a crate::gpio::Pin<'a>,
+    alarm: &'a A,
+    state: MapCell<Sdi12State>,
+    tx_client: OptionalCell<&'a dyn sdi12::TransmitClient>,
+    rx_client: OptionalCell<&'a dyn sdi12::ReceiveClient>,
+}
+
+impl<'a, U: Uart<'a>, A: Alarm<'a>> Sdi12<'a, U, A> {
+    pub fn new(
+        uart: &'a U,
+        uart_pin: &'a crate::gpio::Pin<'a>,
+        command_pin: &'a crate::gpio::Pin<'a>,
+        alarm: &'a A,
+    ) -> Self {
+        Sdi12 {
+            uart,
+            uart_pin,
+            command_pin,
+            alarm,
+            state: MapCell::new(Sdi12State::Idle),
+            tx_client: OptionalCell::empty(),
+            rx_client: OptionalCell::empty(),
+        }
+    }
+}
+
+impl<'a, U: Uart<'a>, A: Alarm<'a>> sdi12::Transmit<'a> for Sdi12<'a, U, A> {
+    fn transmit(
+        &self,
+        data: &'static mut [u8],
+        len: usize,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        // We unwrap here because this is undefined if the state
+        // is None (e.g. should only ever be mapped).
+        let state = self.state.take().unwrap();
+
+        // Set command pin low to prepare for transmission
+        self.command_pin.clear();
+
+        match state {
+            Sdi12State::Idle => {
+                self.state.replace(Sdi12State::TxBreak(len, data));
+            }
+            Sdi12State::Tx(enum_len, enum_data) => {
+                // Already transmitting.
+                self.state.replace(Sdi12State::Tx(enum_len, enum_data));
+                return Err((ErrorCode::BUSY, data));
+            }
+            Sdi12State::TxBreak(stored_len, stored_data) => {
+                // In a pre-transmitting state
+                // Put the existing TxBreak state back and return the incoming buffer
+                self.state
+                    .replace(Sdi12State::TxBreak(stored_len, stored_data));
+                return Err((ErrorCode::BUSY, data));
+            }
+        }
+
+        // send break command
+        self.uart_pin.make_output();
+        self.uart_pin.clear();
+
+        let interval = self.alarm.ticks_from_ms(WAKE_SENSORS_INTERVAL_MS);
+        self.alarm.set_alarm(self.alarm.now(), interval);
+
+        Ok(())
+    }
+
+    fn set_transmit_client(&self, client: &'a dyn sdi12::TransmitClient) {
+        self.tx_client.set(client);
+    }
+}
+
+impl<'a, U: Uart<'a>, A: Alarm<'a>> sdi12::Receive<'a> for Sdi12<'a, U, A> {
+    fn receive(
+        &self,
+        buffer: &'static mut [u8],
+        max_len: usize,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        match self.uart.receive_buffer(buffer, max_len) {
+            Ok(()) => Ok(()),
+            Err((_err, buf)) => Err((ErrorCode::FAIL, buf)),
+        }
+    }
+
+    fn set_receive_client(&self, client: &'a dyn sdi12::ReceiveClient) {
+        self.rx_client.set(client);
+    }
+}
+
+impl<'a, U: Uart<'a>, A: Alarm<'a>> AlarmClient for Sdi12<'a, U, A> {
+    fn alarm(&self) {
+        let state = self.state.take().unwrap();
+        match state {
+            Sdi12State::Idle => {
+                // Should not happen.
+                unreachable!("SDI12 Alarm fired in Idle state.");
+            }
+            Sdi12State::TxBreak(len, data) => {
+                // Time to send marking interval.
+                // let mut data: [u8; 2] = *b"0!"; // send break
+                self.state.replace(Sdi12State::Tx(len, data)); // placeholder length and data
+                self.uart_pin.make_output();
+                self.uart_pin.set();
+
+                let interval = self.alarm.ticks_from_ms(MARKING_INTERVAL_MS);
+                self.alarm.set_alarm(self.alarm.now(), interval);
+            }
+            Sdi12State::Tx(len, data) => {
+                // Time to hold high has elapsed. Reconfigure as alternate function
+                // for USART transmission.
+                self.uart_pin.set_mode(Mode::AlternateFunctionMode);
+                self.uart_pin.set_alternate_function(AlternateFunction::AF7);
+
+                if let Err((err, buf)) = self.uart.transmit_buffer(data, len) {
+                    // Transmission failed, return to Idle state and notify client.
+                    self.state.replace(Sdi12State::Idle);
+                    self.tx_client
+                        .map(|client| client.transmitted_buffer(buf, len, Err(err)));
+                }
+            }
+        }
+    }
+}
+
+impl<'a, U: Uart<'a>, A: Alarm<'a>> uart::TransmitClient for Sdi12<'a, U, A> {
+    fn transmitted_buffer(
+        &self,
+        buffer: &'static mut [u8],
+        length: usize,
+        status: Result<(), ErrorCode>,
+    ) {
+        self.command_pin.set(); // set control pin high for RX mode
+
+        // Transmission complete, set command pin high, return to Idle state and notify client.
+        self.state.replace(Sdi12State::Idle);
+        self.tx_client
+            .map(|client| client.transmitted_buffer(buffer, length, status));
+    }
+}
+
+impl<'a, U: Uart<'a>, A: Alarm<'a>> uart::ReceiveClient for Sdi12<'a, U, A> {
+    fn received_buffer(
+        &self,
+        buffer: &'static mut [u8],
+        length: usize,
+        status: Result<(), ErrorCode>,
+        error: Error,
+    ) {
+        self.state.replace(Sdi12State::Idle);
+        self.rx_client
+            .map(|client| client.receive_buffer(buffer, length, status, error));
+    }
+}

--- a/chips/stm32wle5xx/src/usart.rs
+++ b/chips/stm32wle5xx/src/usart.rs
@@ -434,7 +434,7 @@ impl<'a> Usart<'a> {
     }
 
     pub fn handle_interrupt(&self) {
-        if self.registers.isr.is_set(ISR::TXE) {
+        if self.registers.isr.is_set(ISR::TC) {
             self.disable_transmit_interrupt();
 
             // ignore IRQ if not transmitting
@@ -444,15 +444,10 @@ impl<'a> Usart<'a> {
                         self.registers.tdr.set(buf[self.tx_position.get()].into());
                         self.tx_position.replace(self.tx_position.get() + 1);
                     });
-                }
-                if self.tx_position.get() == self.tx_len.get() {
+                    self.enable_transmit_interrupt();
+                } else {
                     // transmission done
                     self.tx_status.replace(USARTStateTX::Idle);
-                } else {
-                    self.enable_transmit_interrupt();
-                }
-                // notify client if transfer is done
-                if self.tx_status.get() == USARTStateTX::Idle {
                     self.tx_client.map(|client| {
                         if let Some(buf) = self.tx_buffer.take() {
                             client.transmitted_buffer(buf, self.tx_len.get(), Ok(()));
@@ -464,29 +459,28 @@ impl<'a> Usart<'a> {
 
         if self.registers.isr.is_set(ISR::RXNE) {
             let byte = self.registers.rdr.get() as u8;
-            self.disable_receive_interrupt();
 
             // ignore IRQ if not receiving
             if self.rx_status.get() == USARTStateRX::Receiving {
+                // Get next byte
                 if self.rx_position.get() < self.rx_len.get() {
                     self.rx_buffer.map(|buf| {
                         buf[self.rx_position.get()] = byte;
-                        self.rx_position.replace(self.rx_position.get() + 1);
                     });
+                    self.rx_position.set(self.rx_position.get() + 1);
                 }
-                if self.rx_position.get() == self.rx_len.get() {
-                    // reception done
-                    self.rx_status.replace(USARTStateRX::Idle);
-                } else {
-                    self.enable_receive_interrupt();
-                }
-                // notify client if transfer is done
-                if self.rx_status.get() == USARTStateRX::Idle {
+
+                let done = self.rx_position.get() == self.rx_len.get();
+
+                if done {
+                    self.rx_status.set(USARTStateRX::Idle);
+                    self.disable_receive_interrupt();
+
                     self.rx_client.map(|client| {
                         if let Some(buf) = self.rx_buffer.take() {
                             client.received_buffer(
                                 buf,
-                                self.rx_len.get(),
+                                self.rx_position.get(), // pass actual received length
                                 Ok(()),
                                 hil::uart::Error::None,
                             );
@@ -592,41 +586,78 @@ impl<'a> hil::uart::Transmit<'a> for Usart<'a> {
 
 impl hil::uart::Configure for Usart<'_> {
     fn configure(&self, params: hil::uart::Parameters) -> Result<(), ErrorCode> {
-        if params.baud_rate != 115200
-            || params.stop_bits != hil::uart::StopBits::One
-            || params.parity != hil::uart::Parity::None
-            || params.hw_flow_control
-            || params.width != hil::uart::Width::Eight
-        {
-            panic!(
-                "Currently we only support uart setting of 115200bps 8N1, no hardware flow control"
-            );
+        // Flow control
+        if params.hw_flow_control {
+            //panic!("Hardware flow control not supported");
+            return Err(ErrorCode::NOSUPPORT);
         }
 
-        // Configure the word length - 0: 1 Start bit, 8 Data bits, n Stop bits
-        self.registers.cr1.modify(CR1::M0::CLEAR);
-        self.registers.cr1.modify(CR1::M1::CLEAR);
+        // Word length: handle 7 vs 8 later as needed
+        match params.width {
+            hil::uart::Width::Eight => {
+                self.registers.cr1.modify(CR1::M0::CLEAR);
+                self.registers.cr1.modify(CR1::M1::CLEAR);
+            }
+            hil::uart::Width::Seven => {
+                // Set M0/M1 according to reference manual for 7-bit words
+                // (adjust as required by the hardware)
+                self.registers.cr1.modify(CR1::M1::SET);
+                self.registers.cr1.modify(CR1::M0::CLEAR);
+            }
+            _ => {
+                //panic!("Only USART width of 7 or 8 supported");
+                return Err(ErrorCode::NOSUPPORT);
+            }
+        }
 
-        // Set the stop bit length - 00: 1 Stop bits
-        self.registers.cr2.modify(CR2::STOP.val(0b00_u32));
+        // Stop bits
+        match params.stop_bits {
+            hil::uart::StopBits::One => {
+                // Stop bits: already required to be One above
+                self.registers.cr2.modify(CR2::STOP.val(0b00_u32));
+            }
+            _ => {
+                //panic!("Only USART stop bit of 1 supported");
+                return Err(ErrorCode::NOSUPPORT);
+            }
+        }
 
-        // Set no parity
-        self.registers.cr1.modify(CR1::PCE::CLEAR);
+        // Parity
+        match params.parity {
+            hil::uart::Parity::None => {
+                self.registers.cr1.modify(CR1::PCE::CLEAR);
+            }
+            hil::uart::Parity::Even => {
+                self.registers.cr1.modify(CR1::PCE::SET);
+                // PS = 0 => Even
+                self.registers.cr1.modify(CR1::PS::CLEAR);
+            }
+            _ => {
+                //panic!("Only parity of NONE or EVEN supported");
+                return Err(ErrorCode::NOSUPPORT);
+            }
+        }
 
-        // Set the baud rate. By default OVER8 is 0 (oversampling by 16) and
-        // PCLK1 is at 4Mhz. The desired baud rate is 115.2KBps. So according
-        // to Table 159 of reference manual, the value for BRR is 138.8888 (0x8A)
-        // DIV_Fraction = 0x5
-        // DIV_Mantissa = 0x4
-        self.registers.brr.modify(BRR::BRR.val(0x22_u32));
+        // Baud: choose BRR based on requested baud and clock assumptions.
+        // Example values assume PCLK1==4_000_000 and OVER8==0 (oversampling by 16).
+        match params.baud_rate {
+            115200 => {
+                // existing BRR for 115200 used previously
+                self.registers.brr.modify(BRR::BRR.val(0x22_u32));
+            }
+            1200 => {
+                // 4_000_000 / 1200 ~= 3333.333 ; choose nearest mantissa/fraction as needed
+                self.registers.brr.modify(BRR::BRR.val(3333_u32));
+            }
+            _ => {
+                // Shouldn't occur because of earlier check
+                return Err(ErrorCode::NOSUPPORT);
+            }
+        }
 
-        // Enable transmit block
+        // Enable transmit/receive and USART
         self.registers.cr1.modify(CR1::TE::SET);
-
-        // Enable receive block
         self.registers.cr1.modify(CR1::RE::SET);
-
-        // Enable USART
         self.registers.cr1.modify(CR1::UE::SET);
 
         Ok(())
@@ -643,6 +674,12 @@ impl<'a> hil::uart::Receive<'a> for Usart<'a> {
         rx_buffer: &'static mut [u8],
         rx_len: usize,
     ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        // flush any overrun data and clear ORE flag
+        while self.registers.isr.is_set(ISR::RXNE) {
+            let _ = self.registers.rdr.get();
+        }
+        self.registers.icr.modify(ICR::ORECF::SET);
+
         if self.rx_status.get() == USARTStateRX::Idle {
             if rx_len <= rx_buffer.len() {
                 self.rx_buffer.put(Some(rx_buffer));

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -33,6 +33,7 @@ pub mod pwm;
 pub mod radio;
 pub mod rng;
 pub mod screen;
+pub mod sdi12;
 pub mod sensors;
 pub mod servo;
 pub mod spi;

--- a/kernel/src/hil/sdi12.rs
+++ b/kernel/src/hil/sdi12.rs
@@ -1,0 +1,45 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+use crate::ErrorCode;
+use crate::hil::uart::Error;
+
+pub trait Transmit<'a> {
+    fn transmit(
+        &'a self,
+        buffer: &'static mut [u8],
+        len: usize,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])>;
+
+    fn set_transmit_client(&self, client: &'a dyn TransmitClient);
+}
+
+pub trait TransmitClient {
+    fn transmitted_buffer(
+        &self,
+        buffer: &'static mut [u8],
+        length: usize,
+        status: Result<(), ErrorCode>,
+    );
+}
+
+pub trait Receive<'a> {
+    fn receive(
+        &'a self,
+        buffer: &'static mut [u8],
+        max_len: usize,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])>;
+
+    fn set_receive_client(&self, client: &'a dyn ReceiveClient);
+}
+
+pub trait ReceiveClient {
+    fn receive_buffer(
+        &self,
+        buffer: &'static mut [u8],
+        length: usize,
+        status: Result<(), ErrorCode>,
+        error: Error,
+    );
+}


### PR DESCRIPTION
### Pull Request Overview

Fixes all the things wrong with #25. Notably had to do the following

- Enable GPIO C clock
- Correctly send break/marking commands
- Clear parity bit from received cmds (userspace)
- Realized you need to wait for the service request (userspace). The time delay that was implemented did not work.

There's still a ton of bugs, see #51. I just can't be bothered to fix them because of how long its taken already.

Also see https://github.com/jlab-sensing/libtock-c/pull/9 for the necessary userspace changes.

Closes #25 

### Testing Strategy

@jmadden173 with a TEROS-12.


### TODO or Help Wanted

An exorcist to remove all the demons from this 7 month pr....

@tyler-potyondy I did try to move the sdi12 to a component but I don't think I got it right. More ore less AI'ed it since I couldn't figure it out. If you could take a look at it, that would be great.

Also we had to modify the USART peripheral. It looks like it went from full duplex async to only reading data when told so.

### Tock + ENTS Developer PR Form

- [ ] Completed Developer Effort [PR Form](https://docs.google.com/forms/d/1tBf1-ZN9E3iTkloLVHI2tce5ONr77UlecSj8_i53F7Q/viewform?edit_requested=true)

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
