### PR TITLE
Updated RTC to use LSE clock

### DIFF
--- a/chips/stm32wle5xx/src/clocks/phclk.rs
+++ b/chips/stm32wle5xx/src/clocks/phclk.rs
@@ -290,7 +290,7 @@ impl ClockInterface for PeripheralClock<'_> {
                     unimplemented!()
                 }
             },
-            PeripheralClockType::RTC => rcc.enable_rtc_clock(RtcClockSource::LSI),
+            PeripheralClockType::RTC => rcc.enable_rtc_clock(RtcClockSource::LSE),
             PeripheralClockType::APB3(ref v) => match v {
                 PCLK3::SUBGHZSPI => rcc.enable_subghzspi_clock(),
             },


### PR DESCRIPTION
### Pull Request Overview

Changes RTC clock to use LSE. Draft as not tested, but don't want to loose the code.


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...

### Tock + ENTS Developer PR Form

- [ ] Completed Developer Effort [PR Form](https://docs.google.com/forms/d/1tBf1-ZN9E3iTkloLVHI2tce5ONr77UlecSj8_i53F7Q/viewform?edit_requested=true)

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.

### AI Use

- [ ] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
